### PR TITLE
Add expected genomesize calculated from GenomeScope k=31

### DIFF
--- a/species/Amblyraja_radiata.yaml
+++ b/species/Amblyraja_radiata.yaml
@@ -10,3 +10,4 @@ species:
 individuals:
   sAmbRad1:
     species: sAmbRad
+    exp_genome_size: 2072923533

--- a/species/Anabas_testudineus.yaml
+++ b/species/Anabas_testudineus.yaml
@@ -10,3 +10,4 @@ species:
 individuals:
   fAnaTes1:
     species: fAnaTes
+    exp_genome_size: 662696525

--- a/species/Archocentrus_centrarchus.yaml
+++ b/species/Archocentrus_centrarchus.yaml
@@ -10,3 +10,4 @@ species:
 individuals:
   fArcCen1:
     species: fArcCen
+    exp_genome_size: 988048114

--- a/species/Astatotilapia_calliptera.yaml
+++ b/species/Astatotilapia_calliptera.yaml
@@ -10,3 +10,4 @@ species:
 individuals:
   fAstCal1:
     species: fAstCal
+    exp_genome_size: 972478608

--- a/species/Calypte_anna.yaml
+++ b/species/Calypte_anna.yaml
@@ -10,3 +10,4 @@ species:
 individuals:
   bCalAnn1:
     species: bCalAnn
+    exp_genome_size: 1116472572

--- a/species/Cottoperca_gobio.yaml
+++ b/species/Cottoperca_gobio.yaml
@@ -12,3 +12,4 @@ individuals:
     species: fCotGob
   fCotGob3:
     species: fCotGob
+    exp_genome_size: 700000000

--- a/species/Gopherus_evgoodei.yaml
+++ b/species/Gopherus_evgoodei.yaml
@@ -10,3 +10,4 @@ species:
 individuals:
   rGopEvg1:
     species: rGopEvg
+    exp_genome_size: 2684436481

--- a/species/Gouania_willdenowi.yaml
+++ b/species/Gouania_willdenowi.yaml
@@ -10,3 +10,4 @@ species:
 individuals:
   fGouWil2:
     species: fGouWil
+    exp_genome_size: 1182215999

--- a/species/Lynx_canadensis.yaml
+++ b/species/Lynx_canadensis.yaml
@@ -10,3 +10,4 @@ species:
 individuals:
   mLynCan4:
     species: mLynCan
+    exp_genome_size: 2471525315

--- a/species/Mastacembelus_armatus.yaml
+++ b/species/Mastacembelus_armatus.yaml
@@ -10,3 +10,4 @@ species:
 individuals:
   fMasArm1:
     species: fMasArm
+    exp_genome_size: 756753344

--- a/species/Ornithorhynchus_anatinus.yaml
+++ b/species/Ornithorhynchus_anatinus.yaml
@@ -10,5 +10,6 @@ species:
 individuals:
   mOrnAna1:
     species: mOrnAna
+    exp_genome_size: 2128226567
   mOrnAna2:
     species: mOrnAna

--- a/species/Phyllostomus_discolor.yaml
+++ b/species/Phyllostomus_discolor.yaml
@@ -10,3 +10,4 @@ species:
 individuals:
   mPhyDis1:
     species: mPhyDis
+    exp_genome_size: 2213798723

--- a/species/Rhinatrema_bivittatum.yaml
+++ b/species/Rhinatrema_bivittatum.yaml
@@ -10,3 +10,4 @@ species:
 individuals:
   aRhiBiv1:
     species: aRhiBiv
+    exp_genome_size: 5067838282

--- a/species/Rhinolophus_ferrumequinum.yaml
+++ b/species/Rhinolophus_ferrumequinum.yaml
@@ -10,3 +10,4 @@ species:
 individuals:
   mRhiFer1:
     species: mRhiFer
+    exp_genome_size: 2369916842

--- a/species/Strigops_habroptilus.yaml
+++ b/species/Strigops_habroptilus.yaml
@@ -10,3 +10,4 @@ species:
 individuals:
   bStrHab1:
     species: bStrHab
+    exp_genome_size: 1193409022

--- a/species/Taeniopygia_guttata.yaml
+++ b/species/Taeniopygia_guttata.yaml
@@ -10,5 +10,7 @@ species:
 individuals:
   bTaeGut1:
     species: bTaeGut
+    exp_genome_size: 1035611271
   bTaeGut2:
     species: bTaeGut
+    exp_genome_size: 1009982966


### PR DESCRIPTION
Adding the expected genome size per genome, calculated with 10X processed reads.
The k-mer histogram with k=31 was collected with meryl in canu v1.7. 
Expected genome size is obtained by GenomeScope.

The fCotGop3 exp_genomesize was obtained from prior data whilst supported by PacBio read depth of coverage.