### PR TITLE
standardise capitalization of common names

### DIFF
--- a/species/Alca_torda.yaml
+++ b/species/Alca_torda.yaml
@@ -1,5 +1,5 @@
 species:
-  common_name: Razorbill
+  common_name: razorbill
   family:
     name: Alcidae
   genome_size: 1200000000

--- a/species/Amphilophus_labiatus.yaml
+++ b/species/Amphilophus_labiatus.yaml
@@ -1,5 +1,5 @@
 species:
-  common_name: Red devil cichlid
+  common_name: red devil cichlid
   family:
     name: Cichlidae
   genome_size: 1000000000

--- a/species/Astatotilapia_calliptera.yaml
+++ b/species/Astatotilapia_calliptera.yaml
@@ -2,7 +2,7 @@ species:
   short_name: fAstCal
   name: Astatotilapia calliptera
   taxon_id: 8154
-  common_name: eastern happy
+  common_name: Eastern happy
   order:
     name: Cichliformes
   family:

--- a/species/Aythya_fuligula.yaml
+++ b/species/Aythya_fuligula.yaml
@@ -1,5 +1,5 @@
 species:
-  common_name: Tufted duck
+  common_name: tufted duck
   family:
     name: Anatidae
   genome_size: 1200000000

--- a/species/Callithrix_jacchus.yaml
+++ b/species/Callithrix_jacchus.yaml
@@ -1,5 +1,5 @@
 species:
-  common_name: Common marmoset
+  common_name: common marmoset
   family:
     name: Callitrichidae
   genome_size: 3430000000

--- a/species/Chiroxiphia_lanceolata.yaml
+++ b/species/Chiroxiphia_lanceolata.yaml
@@ -1,5 +1,5 @@
 species:
-  common_name: Lance-tailed manakin
+  common_name: lance-tailed manakin
   family:
     name: Pipridae
   genome_size: 1230000000

--- a/species/Cottoperca_gobio.yaml
+++ b/species/Cottoperca_gobio.yaml
@@ -2,7 +2,7 @@ species:
   short_name: fCotGob
   name: Cottoperca gobio
   taxon_id: 56716
-  common_name: Channel bull blenny
+  common_name: channel bull blenny
   order:
     name: Perciformes
   family:

--- a/species/Cygnus_olor.yaml
+++ b/species/Cygnus_olor.yaml
@@ -1,5 +1,5 @@
 species:
-  common_name: Mute swan
+  common_name: mute swan
   family:
     name: Anatidae
   genome_size: 1480000000

--- a/species/Dendropsophus_ebraccatus.yaml
+++ b/species/Dendropsophus_ebraccatus.yaml
@@ -1,5 +1,5 @@
 species:
-  common_name: Hourglass treefrog
+  common_name: hourglass treefrog
   family:
     name: Hylidae
   genome_size: 2520000000

--- a/species/Hirundo_rustica.yaml
+++ b/species/Hirundo_rustica.yaml
@@ -1,5 +1,5 @@
 species:
-  common_name: Barn swallow
+  common_name: barn swallow
   family:
     name: Hirundinidae
   genome_size: 1310000000

--- a/species/Lacerta_agilis.yaml
+++ b/species/Lacerta_agilis.yaml
@@ -1,5 +1,5 @@
 species:
-  common_name: Sand lizard
+  common_name: sand lizard
   family:
     name: Lacertidae
   genome_size: 2000000000

--- a/species/Melopsittacus_undulatus.yaml
+++ b/species/Melopsittacus_undulatus.yaml
@@ -1,5 +1,5 @@
 species:
-  common_name: Budgerigar
+  common_name: budgerigar
   family:
     name: Psittaculidae
   genome_size: 1230000000

--- a/species/Merops_nubicus.yaml
+++ b/species/Merops_nubicus.yaml
@@ -1,5 +1,5 @@
 species:
-  common_name: Carmine bee-eater
+  common_name: carmine bee-eater
   family:
     name: Meropidae
   genome_size: 1300000000

--- a/species/Notolabrus_celidotus.yaml
+++ b/species/Notolabrus_celidotus.yaml
@@ -1,5 +1,5 @@
 species:
-  common_name: Spotty wrasse
+  common_name: spotty wrasse
   family:
     name: Labridae
   genome_size: 1000000000

--- a/species/Petromyzon_marinus.yaml
+++ b/species/Petromyzon_marinus.yaml
@@ -1,5 +1,5 @@
 species:
-  common_name: Sea lamprey
+  common_name: sea lamprey
   family:
     name: Petromyzontidae
   genome_size: 1500000000

--- a/species/Phocoena_sinus.yaml
+++ b/species/Phocoena_sinus.yaml
@@ -1,5 +1,5 @@
 species:
-  common_name: Vaquita
+  common_name: vaquita
   family:
     name: Phocoenidae
   genome_size: 3000000000

--- a/species/Pristis_pectinata.yaml
+++ b/species/Pristis_pectinata.yaml
@@ -1,5 +1,5 @@
 species:
-  common_name: Smalltooth sawfish
+  common_name: smalltooth sawfish
   family:
     name: Pristidae
   genome_size: 2800000000

--- a/species/Pterocles_gutturalis.yaml
+++ b/species/Pterocles_gutturalis.yaml
@@ -1,5 +1,5 @@
 species:
-  common_name: Yellow-throated sandgrouse
+  common_name: yellow-throated sandgrouse
   family:
     name: Pteroclidae
   genome_size: 1070000000

--- a/species/Sterna_hirundo.yaml
+++ b/species/Sterna_hirundo.yaml
@@ -1,5 +1,5 @@
 species:
-  common_name: Common tern
+  common_name: common tern
   family:
     name: Laridae
   genome_size: 1400000000

--- a/species/Sylvia_borin.yaml
+++ b/species/Sylvia_borin.yaml
@@ -1,5 +1,5 @@
 species:
-  common_name: Garden warbler
+  common_name: garden warbler
   family:
     name: Sylviidae
   genome_size: 1200000000

--- a/species/Tachyglossus_aculeatus.yaml
+++ b/species/Tachyglossus_aculeatus.yaml
@@ -1,5 +1,5 @@
 species:
-  common_name: Short-beaked echidna
+  common_name: short-beaked echidna
   family:
     name: Tachyglossidae
   genome_size: 2890000000

--- a/species/Tauraco_erythrolophus.yaml
+++ b/species/Tauraco_erythrolophus.yaml
@@ -1,5 +1,5 @@
 species:
-  common_name: Red-crested turaco
+  common_name: red-crested turaco
   family:
     name: Musophagidae
   genome_size: 1170000000

--- a/species/Trichosurus_vulpecula.yaml
+++ b/species/Trichosurus_vulpecula.yaml
@@ -1,5 +1,5 @@
 species:
-  common_name: Common brushtail possum
+  common_name: common brushtail possum
   family:
     name: Phalangeridae
   genome_size: 3000000000


### PR DESCRIPTION
Use lower case for common names, except for proper nouns. We have a mixture of styles at the moment.